### PR TITLE
qbd mapping table css fix

### DIFF
--- a/src/app/shared/components/qbd/mapping/mapping-table/mapping-table.component.scss
+++ b/src/app/shared/components/qbd/mapping/mapping-table/mapping-table.component.scss
@@ -1,5 +1,5 @@
 th {
-    @apply tw-text-12-px tw-text-normal-text-color tw-font-500 tw-h-40-px tw-py-12-px tw-px-24-px tw-bg-disabled-bg-color tw-border-r-1-px tw-border-box-color #{!important};
+    @apply tw-text-12-px tw-text-normal-text-color tw-font-500 tw-py-12-px tw-px-24-px tw-bg-disabled-bg-color tw-border-r-1-px tw-border-box-color #{!important};
 }
 
 td {


### PR DESCRIPTION
<img width="687" alt="Screenshot 2023-09-27 at 11 49 44 AM" src="https://github.com/fylein/fyle-integrations-settings-app/assets/55541808/e5fda23f-c932-41f8-b35e-3ec9c0eb4fac">
fixing mapping table header css change in qbd mapping